### PR TITLE
AOP Implementation - for example, not to be merged

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.retry:spring-retry'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/shankulk/aop/RestTemplateRetryAspect.java
+++ b/src/main/java/com/shankulk/aop/RestTemplateRetryAspect.java
@@ -1,0 +1,24 @@
+package com.shankulk.aop;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@Aspect
+public class RestTemplateRetryAspect {
+
+    private RetryTemplate retryTemplate;
+
+    public RestTemplateRetryAspect(RetryTemplate retryTemplate) {
+        this.retryTemplate = retryTemplate;
+    }
+
+    @Around("execution(public * org.springframework.web.client.RestTemplate.*(..))")
+    public Object executionTime(final ProceedingJoinPoint point)
+        throws Throwable {
+        return retryTemplate.execute(context -> point.proceed());
+    }
+}

--- a/src/main/java/com/shankulk/client/ImdbRapidApiClient.java
+++ b/src/main/java/com/shankulk/client/ImdbRapidApiClient.java
@@ -4,12 +4,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
 @Component
 @SuppressWarnings("SpringJavaAutowiredFieldsWarningInspection")
-public class ImdbRapidApiClient extends BaseRetryableApiClient {
+public class ImdbRapidApiClient {
 
     private static final String URL = "https://imdb8.p.rapidapi.com/title/auto-complete?q=deathly%20hallows";
 
@@ -24,6 +25,6 @@ public class ImdbRapidApiClient extends BaseRetryableApiClient {
         headers.add("x-rapidapi-host", "imdb8.p.rapidapi.com");
         headers.add("x-rapidapi-key", rapidApiKey);
 
-        return get(restTemplate, URL, new HttpEntity<>(headers), String.class);
+        return restTemplate.exchange(URL, HttpMethod.GET, new HttpEntity<>(headers), String.class).getBody();
     }
 }

--- a/src/main/java/com/shankulk/config/RetryConfig.java
+++ b/src/main/java/com/shankulk/config/RetryConfig.java
@@ -44,6 +44,8 @@ public class RetryConfig {
             case SERVICE_UNAVAILABLE:
             case INTERNAL_SERVER_ERROR:
             case GATEWAY_TIMEOUT:
+            case FORBIDDEN:
+            case TOO_MANY_REQUESTS:
                 return simpleRetryPolicy;
             default:
                 return neverRetryPolicy;

--- a/src/test/java/com/shankulk/client/ImdbRapidApiClientIntegrationTest.java
+++ b/src/test/java/com/shankulk/client/ImdbRapidApiClientIntegrationTest.java
@@ -42,24 +42,24 @@ public class ImdbRapidApiClientIntegrationTest {
   @ParameterizedTest
   @MethodSource("allowedHttpStatusCodes")
   void retriableExceptions_testRetryWorks(HttpStatus httpStatus) {
-    given(
-            restTemplate.exchange(
-                anyString(),
-                eq(HttpMethod.GET),
-                any(HttpEntity.class),
-                eq(String.class),
-                any(Object[].class)))
-        .willThrow(new HttpServerErrorException(httpStatus));
+//    given(
+//            restTemplate.exchange(
+//                anyString(),
+//                eq(HttpMethod.GET),
+//                any(HttpEntity.class),
+//                eq(String.class),
+//                any(Object[].class)))
+//        .willThrow(new HttpServerErrorException(httpStatus));
 
     Assertions.assertThrows(HttpServerErrorException.class, () -> imdbRapidApiClient.getImdbTitle());
 
-    verify(restTemplate, times(2))
-        .exchange(
-            anyString(),
-            eq(HttpMethod.GET),
-            any(HttpEntity.class),
-            eq(String.class),
-            any(Object[].class));
+//    verify(restTemplate, times(2))
+//        .exchange(
+//            anyString(),
+//            eq(HttpMethod.GET),
+//            any(HttpEntity.class),
+//            eq(String.class),
+//            any(Object[].class));
   }
 
   @ParameterizedTest
@@ -68,23 +68,23 @@ public class ImdbRapidApiClientIntegrationTest {
       names = {"BAD_GATEWAY", "SERVICE_UNAVAILABLE", "INTERNAL_SERVER_ERROR", "GATEWAY_TIMEOUT"},
       mode = Mode.EXCLUDE)
   void clientErrorException_testNoRetries(HttpStatus httpStatus) {
-    given(
-            restTemplate.exchange(
-                anyString(),
-                eq(HttpMethod.GET),
-                any(HttpEntity.class),
-                eq(String.class),
-                any(Object[].class)))
-        .willThrow(new HttpClientErrorException(httpStatus));
+//    given(
+//            restTemplate.exchange(
+//                anyString(),
+//                eq(HttpMethod.GET),
+//                any(HttpEntity.class),
+//                eq(String.class),
+//                any(Object[].class)))
+//        .willThrow(new HttpClientErrorException(httpStatus));
 
     Assertions.assertThrows(HttpClientErrorException.class, () -> imdbRapidApiClient.getImdbTitle());
 
-    verify(restTemplate, times(1))
-        .exchange(
-            anyString(),
-            eq(HttpMethod.GET),
-            any(HttpEntity.class),
-            eq(String.class),
-            any(Object[].class));
+//    verify(restTemplate, times(1))
+//        .exchange(
+//            anyString(),
+//            eq(HttpMethod.GET),
+//            any(HttpEntity.class),
+//            eq(String.class),
+//            any(Object[].class));
   }
 }


### PR DESCRIPTION
- I had to upgrade gradle for some reason. My spring boot plugin wouldn't support the old version.
- Adding `spring-boot-starter-aop` dependency.
- Adding `RestTemplateRetryAspect`. This is blanket on any `RestTemplate` beans, but you could modify the pointcut to be a specific bean if desired. I'm also a fan of using constructor wiring instead of `@Autowired`.
- No need to extend `BaseRetryableApiClient` or call it's `get` method. Just use `RestTemplate` out-of-the-box.
- Added `FORBIDDEN` and `TOO_MANY_REQUESTS` to the `RetryConfig` for my local testing as hitting the URL gave me those errors.
- I modified the test manually to make sure it worked as mocking the bean avoids the AOP completely. I'm not sure the best way to test it in the future. Possibly by creating some kind of local endpoint(s) to call where each endpoint returns a different error.